### PR TITLE
Support Python 3

### DIFF
--- a/lektor_shortcodes/__init__.py
+++ b/lektor_shortcodes/__init__.py
@@ -4,7 +4,7 @@ from lektor.pluginsystem import Plugin
 from lektor.markdown import Markdown
 from markupsafe import Markup
 
-import scodes
+from . import scodes
 
 
 def shortcode_factory(config):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='lektor-shortcodes',
-    version='0.1.5',
+    version='0.1.6',
     author=u'Stavros Korokithakis,,,',
     author_email='hi@stavros.io',
     url='https://github.com/skorokithakis/lektor-shortcodes',


### PR DESCRIPTION
As of Python 3, relative imports must use the «from . import…» form. «import
scodes» is regarded as an absolute import when running on Python 3 and will
trigger an ImportError.