### PR TITLE
Support globally defined shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ to be on one line.
 For instance, for the example above, the config file could be:
 
 ~~~ini
-[main]
+[global]
 image = '<div class="align{{ align }}">{% if link %}<a href="{{ link }}"{% if not link.startswith("http") %} data-lightbox="gallery"{% endif %}>{% endif %}<img src="{{ image }}">{% if link %}</a>{% endif %}{% if caption %}<span class="caption">{{ caption }}</span>{% endif %}</div>'
 ~~~
 
@@ -71,22 +71,22 @@ This will allow you to use shortcodes with optional arguments, like so:
 [% image align=right link=http://www.example.com image=hello.jpg caption="Hello!" %]
 ~~~
 
-To actually make the above work, you need to use the `shortcode` filter in your
-template. For example, if the field is called `body`, in your html template
-that you reference the `body` field you'd add:
+Shortcodes defined within the section named `global` will be processed
+automatically inside any of your site’s Markdown content. It is also possible to
+define shortcodes which are only expanded when the Jinja2 template for a page
+explicitly requests it. Shortcodes defined in any section not named `global`
+will only be applied when the template passed the content through a Jinja2
+filter named `shortcode`. For example, if your HTML template references a field
+called `body`, you may request expanding shortcodes defined within the
+`body-only` section of your config file, like so:
 
 ~~~
-{{ body|shortcodes }}
+{{ body|shortcodes(section="body-only") }}
 ~~~
 
-This will use the default section, `main`. If you want, you can specify the
-section too:
-
-~~~
-{{ body|shortcodes(section="post-codes") }}
-~~~
-
-And this would look for a section called `post-codes` in the ini file.
+This will enable all shortcodes from the specified section, in addition to all
+globally defined shortcodes. If no section is specified, the filter defaults to
+the section named `main`.
 
 
 Miscellanea

--- a/lektor_shortcodes/__init__.py
+++ b/lektor_shortcodes/__init__.py
@@ -66,7 +66,10 @@ class ShortcodesPlugin(Plugin):
     description = u'Shortcodes for Lektor.'
 
     def on_markdown_config(self, config):
-        lexer = ShortcodeLexer(self.get_config())
+        shortcodes_config = self.get_config()
+        if not shortcodes_config.section_as_dict('global'):
+            return
+        lexer = ShortcodeLexer(shortcodes_config)
         config.options['block'] = lexer
 
     def on_setup_env(self, **extra):

--- a/lektor_shortcodes/__init__.py
+++ b/lektor_shortcodes/__init__.py
@@ -1,18 +1,49 @@
 # -*- coding: utf-8 -*-
+import re
+import itertools
+
 from jinja2 import Template
 from lektor.pluginsystem import Plugin
 from lektor.markdown import Markdown
 from markupsafe import Markup
+from mistune import BlockLexer, BlockGrammar
 
 from . import scodes
 
 
+class ShortcodeLexer(BlockLexer):
+
+    def __init__(self, config):
+        BlockLexer.__init__(self)
+        self._init_shortcodes_compiler(config)
+        self._init_shortcodes_lexer()
+
+    def _init_shortcodes_lexer(self):
+        self.rules.shortcode = re.compile(r'(\[% .+? %\])')
+        self.default_rules.insert(1, 'shortcode')
+
+    def _init_shortcodes_compiler(self, config):
+        self.compile = shortcode_factory(config)
+
+    def parse_shortcode(self, match):
+        text = match.group(1)
+        self.tokens.append({
+            'type': 'close_html',
+            'text': self.compile(text)
+        })
+
+
 def shortcode_factory(config):
+
     def shortcodes(text, **options):
-        section = options.get("section", "main")
+        sections = ("global", options.get("section", "main"))
+        shortcodes =  itertools.chain(*(
+            config.section_as_dict(section).items()
+            for section in sections
+        ))
 
         parser = scodes.Parser()
-        for item, conf in config.section_as_dict(section).items():
+        for item, conf in shortcodes:
             # Make a closure so the correct config object passes through.
             def handler_closure(cconf):
                 def handler(context, content, pargs, kwargs):
@@ -33,6 +64,10 @@ def shortcode_factory(config):
 class ShortcodesPlugin(Plugin):
     name = u'lektor-shortcodes'
     description = u'Shortcodes for Lektor.'
+
+    def on_markdown_config(self, config):
+        lexer = ShortcodeLexer(self.get_config())
+        config.options['block'] = lexer
 
     def on_setup_env(self, **extra):
         self.env.jinja_env.filters['shortcodes'] = shortcode_factory(self.get_config())


### PR DESCRIPTION
This adds support for a new config block, «global». Shortcodes defined in this
block are always applied, even when the jinja2 filter is not used. In case the
jinja2 filter is used, shortcodes from this section are applied in addition to
the shortcodes specified by the filter.