### PR TITLE
decode_escapes: support both py2 and py3

### DIFF
--- a/lektor_shortcodes/scodes.py
+++ b/lektor_shortcodes/scodes.py
@@ -34,9 +34,12 @@ def register(tag, end_tag=None):
 
 
 # Decode unicode escape sequences in a string.
-def decode_escapes(s):
-    return bytes(s).decode('unicode_escape')
-
+if sys.version_info < (3,):
+    def decode_escapes(s):
+        return bytes(s).decode('unicode_escape')
+else:
+    def decode_escapes(s):
+        return s.encode('latin-1').decode('unicode_escape')
 
 # --------------------------------------------------------------------------
 # Exception classes.


### PR DESCRIPTION
Since strings are no longer bytestrings in Python 3, we have to specify an
encoding to generate a sequence of bytes. We must choose latin-1 here, since the
unicode_escape codec assumes that the byte sequence is encoded ASCII or
latin-1 (cf. [1]).

[1] <https://stackoverflow.com/questions/4020539>