### PR TITLE
Catch (and ignore) extra params to on_markdown_config()

### DIFF
--- a/lektor_shortcodes/__init__.py
+++ b/lektor_shortcodes/__init__.py
@@ -86,7 +86,7 @@ class ShortcodesPlugin(Plugin):
                 self.get_config(), ctx=context, env=self.env.jinja_env
             )
 
-    def on_markdown_config(self, config):
+    def on_markdown_config(self, config, **extra):
         shortcodes_config = self.get_config()
         if not shortcodes_config.section_as_dict("global"):
             return


### PR DESCRIPTION
Hello, and thanks for the plugin.

Lektor on latest master now passes `extra_flags` to all even handlers. If a plugin isn't prepared for this, it can result in exceptions: lektor/lektor#652. 

Per the [recommendations in the docs](https://www.getlektor.com/docs/api/plugins/events/#handling-events), this PR makes `on_markdown_config()` catch any such extra params in `**extra`